### PR TITLE
+ Fix Shugo Express Cooldown time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,7 @@
 *.tar.gz
 *.rar
 
+build/
+
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*

--- a/AL-Game/src/com/aionemu/gameserver/network/aion/clientpackets/CM_READ_EXPRESS_MAIL.java
+++ b/AL-Game/src/com/aionemu/gameserver/network/aion/clientpackets/CM_READ_EXPRESS_MAIL.java
@@ -65,7 +65,7 @@ public class CM_READ_EXPRESS_MAIL extends AionClientPacket {
 				else if (player.isFlying()) {
 					PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_POSTMAN_UNABLE_IN_FLIGHT);
 				}
-				else if (player.getController().hasTask(TaskId.EXPRESS_MAIL_USE)) {
+				else if (player.getController().hasScheduledTask(TaskId.EXPRESS_MAIL_USE)) {
 					PacketSendUtility.sendPacket(player, SM_SYSTEM_MESSAGE.STR_POSTMAN_UNABLE_IN_COOLTIME);
 				}
 				else if (haveUnreadExpress) {


### PR DESCRIPTION
This Changes will fix Shugo Cooldown Time,
If you realize that shugo can never be called again for the second time, It always says that it is On Cooldown, Even if you have waited for 10 minutes Or an 1 hour or A year... The shugo was never finished from it's cooldown

Issues #150 